### PR TITLE
Fix an error on require("firebase-node.js")

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,4 +1,4 @@
-var Firebase = require("./firebase-node.js");
+var Firebase = require("firebase");
 var newWorkPeriod = 700;
 var workItems = new Firebase("https://workqueue.firebaseio-demo.com/");
 

--- a/worker.js
+++ b/worker.js
@@ -1,4 +1,4 @@
-var Firebase = require("./firebase-node.js");
+var Firebase = require("firebase");
 var WorkQueue = require("./workqueue.js");
 
 var itemsRef = new Firebase("https://workqueue.firebaseio-demo.com/");


### PR DESCRIPTION
```
Error: Cannot find module 'firebase-node.js'
```

worker.js and generator.js do `require("firebase-node.js")`.
However, in README.md, the instruction `npm install firebase` imply that requiring "firebase" from "node_modules".

This seems to be trivial for those who well experienced with node.js, but not for beginner like me.
